### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # StudentRecord-c-
-1. Create students records in structure with Name, SudentID and Marks (not hardcored, Dynamicaly pickup from user entry).
+1. Create students records in structure with Name, StudentID and Marks (not hardcoded, Dynamically pickup from user entry).
 2. Sort the student structure based on their Marks and assign rank.
 3. Display Records based on Ranks.
 


### PR DESCRIPTION
## Summary
- fix a few typos in `README.md`

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684b62050d7883209a27a0d1d1c67f25