### PR TITLE
Add MSTest project with sorting test

### DIFF
--- a/Student.Tests/Student.Tests.csproj
+++ b/Student.Tests/Student.Tests.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F1F5BFEB-0A16-4D3E-A4A0-AE2B0BB2F0F0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Student.Tests</RootNamespace>
+    <AssemblyName>Student.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="StudentTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Student.csproj" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Student.Tests/StudentTests.cs
+++ b/Student.Tests/StudentTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Student;
+using System.Collections.Generic;
+
+namespace Student.Tests
+{
+    [TestClass]
+    public class StudentsSortingTests
+    {
+        [TestMethod]
+        public void SortStudentRecords_SortsByMarksDescending()
+        {
+            var students = new Students();
+            students.StoreStudentRecords("Alice", 1, 50);
+            students.StoreStudentRecords("Bob", 2, 70);
+            students.StoreStudentRecords("Carol", 3, 40);
+            students.SortStudentRecords();
+            var marks = students.GetSortedMarks();
+            var expected = new List<int> { 70, 50, 40 };
+            CollectionAssert.AreEqual(expected, marks);
+        }
+    }
+}

--- a/Student.sln
+++ b/Student.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.960
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Student", "Student\Student.csproj", "{B6BF7602-7F25-4644-A578-65E7D8A48621}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Student", "Student.csproj", "{B6BF7602-7F25-4644-A578-65E7D8A48621}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Student.Tests", "Student.Tests\Student.Tests.csproj", "{A0F9F09C-F0B6-4F76-8B9E-E458FFBD05F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,8 +16,12 @@ Global
 		{B6BF7602-7F25-4644-A578-65E7D8A48621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B6BF7602-7F25-4644-A578-65E7D8A48621}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6BF7602-7F25-4644-A578-65E7D8A48621}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B6BF7602-7F25-4644-A578-65E7D8A48621}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B6BF7602-7F25-4644-A578-65E7D8A48621}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A0F9F09C-F0B6-4F76-8B9E-E458FFBD05F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A0F9F09C-F0B6-4F76-8B9E-E458FFBD05F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A0F9F09C-F0B6-4F76-8B9E-E458FFBD05F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A0F9F09C-F0B6-4F76-8B9E-E458FFBD05F8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Students.cs
+++ b/Students.cs
@@ -35,6 +35,15 @@ namespace Student
             var linq = (from record in records orderby record._studentMarks descending select record).ToList();
             studrecords = linq.ToList();
         }
+
+        public List<int> GetSortedMarks()
+        {
+            if (studrecords == null)
+            {
+                return new List<int>();
+            }
+            return studrecords.Select(r => r._studentMarks).ToList();
+        }
         public void DisplayStudentRecords()                                 // display student records with rank
         {
             


### PR DESCRIPTION
## Summary
- add a new MSTest project `Student.Tests`
- expose `GetSortedMarks` helper in `Students`
- test that `SortStudentRecords` orders marks descending
- reference the new project in the solution

## Testing
- *No tests run due to missing .NET tooling in the environment*

------
https://chatgpt.com/codex/tasks/task_e_684b620855f08320a7af5a7f7a0b6991